### PR TITLE
Refactor api

### DIFF
--- a/backend/eatgo/settings.py
+++ b/backend/eatgo/settings.py
@@ -21,6 +21,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # .env 파일 로드
 load_dotenv(BASE_DIR.parent / ".env.local")
 
+
+API_VERSION = "/api/v1"
+
 # KAKAO REST API KEY 환경변수 등록
 KAKAO_REST_API_KEY = os.environ.get("KAKAO_REST_API_KEY")
 

--- a/backend/eatgo/urls.py
+++ b/backend/eatgo/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
         name="schema-swagger-ui",
     ),
     path("admin/", admin.site.urls),
-    path("/redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
     # api
     path(settings.API_VERSION + "/kakaomap/", include("kakaomap.urls")),
     path(settings.API_VERSION + "/routes/", include("routes.urls")),

--- a/backend/eatgo/urls.py
+++ b/backend/eatgo/urls.py
@@ -18,6 +18,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework import permissions
+from django.conf import settings
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
@@ -43,12 +44,12 @@ urlpatterns = [
         schema_view.with_ui("swagger", cache_timeout=0),
         name="schema-swagger-ui",
     ),
-    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
-    # api
     path("admin/", admin.site.urls),
-    path("kakaomap/", include("kakaomap.urls")),
-    path("routes/", include("routes.urls")),
-    path("travel_courses/", include("travel_courses.urls")),
-    path("api/tourism/", include("tourism.urls")),
+    path("/redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    # api
+    path(settings.API_VERSION + "/kakaomap/", include("kakaomap.urls")),
+    path(settings.API_VERSION + "/routes/", include("routes.urls")),
+    path(settings.API_VERSION + "/travel_courses/", include("travel_courses.urls")),
+    path(settings.API_VERSION + "/tourism/", include("tourism.urls")),
     # path('api-auth/', include('rest_framework.urls')),
 ]

--- a/backend/kakaomap/urls.py
+++ b/backend/kakaomap/urls.py
@@ -1,20 +1,20 @@
 from django.urls import path
 from .views import (
-    get_kakao_map,
-    search_places_from_kakao,
-    calculate_distance,
-    get_route_info_from_kakao,
-    calculate_multi_point_distance,
+    KakaoMapView,
+    SearchPlacesView,
+    CalculateDistanceView,
+    RouteInfoView,
+    OptimizeRouteView,
 )
 
 urlpatterns = [
-    path("map/", get_kakao_map, name="get_kakao_map"),
-    path("search/", search_places_from_kakao, name="search_places_from_kakao"),
-    path("distance/", calculate_distance, name="calculate_distance"),
-    path("route/", get_route_info_from_kakao, name="get_route_info"),
+    path("map/", KakaoMapView.as_view(), name="get_kakao_map"),
+    path("search/", SearchPlacesView.as_view(), name="search_places_from_kakao"),
+    path("distance/", CalculateDistanceView.as_view(), name="calculate_distance"),
+    path("route/", RouteInfoView.as_view(), name="get_route_info"),
     path(
         "optimize-route/",
-        calculate_multi_point_distance,
+        OptimizeRouteView.as_view(),
         name="calculate_multi_point_distance",
     ),
 ]

--- a/backend/kakaomap/views.py
+++ b/backend/kakaomap/views.py
@@ -1,5 +1,7 @@
-from django.http import JsonResponse
 from django.conf import settings
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
 import requests
 import math
 
@@ -17,54 +19,72 @@ def map_kakao_category_to_place_type(category_group_code):
         return "ETC"
 
 
-def get_kakao_map(request):
-    lat = request.GET.get("lat")
-    lng = request.GET.get("lng")
-    if not lat or not lng:
-        return JsonResponse({"error": "lat, lng required"}, status=400)
-    url = f"https://dapi.kakao.com/v2/maps/staticmap?center={lng},{lat}&level=3&w=500&h=400"
-    # headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
-    # 실제로 이미지를 받아오지 않고, URL만 반환
-    return JsonResponse({"map_url": url})
+class KakaoMapView(APIView):
+    """
+    Get Kakao Map static image URL
+    """
+
+    def get(self, request):
+        lat = request.GET.get("lat")
+        lng = request.GET.get("lng")
+        if not lat or not lng:
+            return Response(
+                {"error": "lat, lng required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        url = f"https://dapi.kakao.com/v2/maps/staticmap?center={lng},{lat}&level=3&w=500&h=400"
+        # headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
+        # 실제로 이미지를 받아오지 않고, URL만 반환
+        return Response({"map_url": url})
 
 
-def search_places_from_kakao(request):
-    query = request.GET.get("query")
-    if not query:
-        return JsonResponse({"error": "query required"}, status=400)
-    url = "https://dapi.kakao.com/v2/local/search/keyword.json"
-    headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
-    params = {"query": query, "page": 1, "size": 15, "sort": "accuracy"}
-    try:
-        response = requests.get(url, headers=headers, params=params)
-        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx and 5xx)
-        print("카카오 응답:", response.text)  # 실제 응답을 로그로 출력
-        data = response.json()
-    except requests.exceptions.RequestException as e:
-        return JsonResponse(
-            {"error": f"Failed to fetch data from Kakao API: {str(e)}"}, status=500
-        )
-    except ValueError:
-        return JsonResponse(
-            {"error": "Invalid JSON response from Kakao API"}, status=500
-        )
-    results = []
-    for doc in data.get("documents", []):
-        place_type = map_kakao_category_to_place_type(doc.get("category_group_code"))
-        results.append(
-            {
-                "name": doc.get("place_name"),
-                "address": doc.get("address_name"),
-                "road_address": doc.get("road_address_name"),
-                "lat": float(doc["y"]) if doc.get("y") else None,
-                "lng": float(doc["x"]) if doc.get("x") else None,
-                "external_id": doc.get("id"),
-                "external_url": doc.get("place_url"),
-                "place_type": place_type,
-                "phone_number": doc.get("phone"),
-            }
-        )
-    return JsonResponse({"results": results})
+class SearchPlacesView(APIView):
+    """
+    Search places from Kakao Local API
+    """
+
+    def get(self, request):
+        query = request.GET.get("query")
+        if not query:
+            return Response(
+                {"error": "query required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        url = "https://dapi.kakao.com/v2/local/search/keyword.json"
+        headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
+        params = {"query": query, "page": 1, "size": 15, "sort": "accuracy"}
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()  # Raise an HTTPError for bad responses (4xx and 5xx)
+            print("카카오 응답:", response.text)  # 실제 응답을 로그로 출력
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            return Response(
+                {"error": f"Failed to fetch data from Kakao API: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        except ValueError:
+            return Response(
+                {"error": "Invalid JSON response from Kakao API"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        results = []
+        for doc in data.get("documents", []):
+            place_type = map_kakao_category_to_place_type(
+                doc.get("category_group_code")
+            )
+            results.append(
+                {
+                    "name": doc.get("place_name"),
+                    "address": doc.get("address_name"),
+                    "road_address": doc.get("road_address_name"),
+                    "lat": float(doc["y"]) if doc.get("y") else None,
+                    "lng": float(doc["x"]) if doc.get("x") else None,
+                    "external_id": doc.get("id"),
+                    "external_url": doc.get("place_url"),
+                    "place_type": place_type,
+                    "phone_number": doc.get("phone"),
+                }
+            )
+        return Response({"results": results})
 
 
 def calculate_distance_haversine(lat1, lng1, lat2, lng2):
@@ -92,154 +112,162 @@ def calculate_distance_haversine(lat1, lng1, lat2, lng2):
     return distance
 
 
-def calculate_distance(request):
+class CalculateDistanceView(APIView):
     """
     Calculate straight-line distance between two points
     """
-    try:
-        lat1 = float(request.GET.get("lat1"))
-        lng1 = float(request.GET.get("lng1"))
-        lat2 = float(request.GET.get("lat2"))
-        lng2 = float(request.GET.get("lng2"))
-    except (TypeError, ValueError):
-        return JsonResponse(
-            {"error": "lat1, lng1, lat2, lng2 required as numbers"}, status=400
+
+    def get(self, request):
+        try:
+            lat1 = float(request.GET.get("lat1"))
+            lng1 = float(request.GET.get("lng1"))
+            lat2 = float(request.GET.get("lat2"))
+            lng2 = float(request.GET.get("lng2"))
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "lat1, lng1, lat2, lng2 required as numbers"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        distance_km = calculate_distance_haversine(lat1, lng1, lat2, lng2)
+
+        return Response(
+            {
+                "distance_km": round(distance_km, 2),
+                "distance_m": round(distance_km * 1000, 0),
+            }
         )
 
-    distance_km = calculate_distance_haversine(lat1, lng1, lat2, lng2)
 
-    return JsonResponse(
-        {
-            "distance_km": round(distance_km, 2),
-            "distance_m": round(distance_km * 1000, 0),
-        }
-    )
-
-
-def get_route_info_from_kakao(request):
+class RouteInfoView(APIView):
     """
     Get route information (distance, duration) between two points using Kakao Map API
     """
-    try:
-        origin_lat = float(request.GET.get("origin_lat"))
-        origin_lng = float(request.GET.get("origin_lng"))
-        destination_lat = float(request.GET.get("destination_lat"))
-        destination_lng = float(request.GET.get("destination_lng"))
-        priority = request.GET.get("priority", "RECOMMEND")  # RECOMMEND, TIME, DISTANCE
-    except (TypeError, ValueError):
-        return JsonResponse(
-            {
-                "error": "origin_lat, origin_lng, destination_lat, destination_lng required as numbers"
-            },
-            status=400,
-        )
 
-    url = "https://apis-navi.kakaomobility.com/v1/directions"
-    headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
-    params = {
-        "origin": f"{origin_lng},{origin_lat}",
-        "destination": f"{destination_lng},{destination_lat}",
-        "priority": priority,
-        "car_fuel": "GASOLINE",
-        "car_hipass": "false",
-        "alternatives": "false",
-        "road_details": "false",
-    }
-
-    try:
-        response = requests.get(url, headers=headers, params=params)
-        response.raise_for_status()
-        data = response.json()
-
-        if data.get("routes"):
-            route = data["routes"][0]
-            summary = route.get("summary", {})
-
-            return JsonResponse(
+    def get(self, request):
+        try:
+            origin_lat = float(request.GET.get("origin_lat"))
+            origin_lng = float(request.GET.get("origin_lng"))
+            destination_lat = float(request.GET.get("destination_lat"))
+            destination_lng = float(request.GET.get("destination_lng"))
+            priority = request.GET.get(
+                "priority", "RECOMMEND"
+            )  # RECOMMEND, TIME, DISTANCE
+        except (TypeError, ValueError):
+            return Response(
                 {
-                    "distance_m": summary.get("distance", 0),
-                    "distance_km": round(summary.get("distance", 0) / 1000, 2),
-                    "duration_sec": summary.get("duration", 0),
-                    "duration_min": round(summary.get("duration", 0) / 60, 1),
-                    "fare": summary.get("fare", 0),
-                    "priority": priority,
-                }
+                    "error": "origin_lat, origin_lng, destination_lat, destination_lng required as numbers"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        else:
-            return JsonResponse({"error": "No route found"}, status=404)
 
-    except requests.exceptions.RequestException as e:
-        return JsonResponse(
-            {"error": f"Failed to fetch route data from Kakao API: {str(e)}"},
-            status=500,
-        )
-    except ValueError:
-        return JsonResponse(
-            {"error": "Invalid JSON response from Kakao API"}, status=500
-        )
+        url = "https://apis-navi.kakaomobility.com/v1/directions"
+        headers = {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
+        params = {
+            "origin": f"{origin_lng},{origin_lat}",
+            "destination": f"{destination_lng},{destination_lat}",
+            "priority": priority,
+            "car_fuel": "GASOLINE",
+            "car_hipass": "false",
+            "alternatives": "false",
+            "road_details": "false",
+        }
+
+        try:
+            response = requests.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+            if data.get("routes"):
+                route = data["routes"][0]
+                summary = route.get("summary", {})
+
+                return Response(
+                    {
+                        "distance_m": summary.get("distance", 0),
+                        "distance_km": round(summary.get("distance", 0) / 1000, 2),
+                        "duration_sec": summary.get("duration", 0),
+                        "duration_min": round(summary.get("duration", 0) / 60, 1),
+                        "fare": summary.get("fare", 0),
+                        "priority": priority,
+                    }
+                )
+            else:
+                return Response(
+                    {"error": "No route found"}, status=status.HTTP_404_NOT_FOUND
+                )
+
+        except requests.exceptions.RequestException as e:
+            return Response(
+                {"error": f"Failed to fetch route data from Kakao API: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        except ValueError:
+            return Response(
+                {"error": "Invalid JSON response from Kakao API"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
 
-def calculate_multi_point_distance(request):
+class OptimizeRouteView(APIView):
     """
     Calculate total distance for multiple points (route optimization)
     Input: JSON array of coordinates
     Output: Total distance and optimized order
     """
-    import json
 
-    if request.method != "POST":
-        return JsonResponse({"error": "POST method required"}, status=405)
+    def post(self, request):
+        try:
+            points = request.data.get("points", [])
 
-    try:
-        data = json.loads(request.body)
-        points = data.get("points", [])
-
-        if len(points) < 2:
-            return JsonResponse({"error": "At least 2 points required"}, status=400)
-
-        # Simple nearest neighbor algorithm for route optimization
-        # Start from first point (user location)
-        optimized_order = [0]
-        current_point = 0
-        unvisited = list(range(1, len(points)))
-        total_distance = 0
-
-        while unvisited:
-            current_lat = points[current_point]["lat"]
-            current_lng = points[current_point]["lng"]
-
-            # Find nearest unvisited point
-            min_distance = float("inf")
-            nearest_point = None
-
-            for point_idx in unvisited:
-                point_lat = points[point_idx]["lat"]
-                point_lng = points[point_idx]["lng"]
-                distance = calculate_distance_haversine(
-                    current_lat, current_lng, point_lat, point_lng
+            if len(points) < 2:
+                return Response(
+                    {"error": "At least 2 points required"},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
 
-                if distance < min_distance:
-                    min_distance = distance
-                    nearest_point = point_idx
+            # Simple nearest neighbor algorithm for route optimization
+            # Start from first point (user location)
+            optimized_order = [0]
+            current_point = 0
+            unvisited = list(range(1, len(points)))
+            total_distance = 0
 
-            # Move to nearest point
-            optimized_order.append(nearest_point)
-            unvisited.remove(nearest_point)
-            total_distance += min_distance
-            current_point = nearest_point
+            while unvisited:
+                current_lat = points[current_point]["lat"]
+                current_lng = points[current_point]["lng"]
 
-        return JsonResponse(
-            {
-                "total_distance_km": round(total_distance, 2),
-                "optimized_order": optimized_order,
-                "points_count": len(points),
-            }
-        )
+                # Find nearest unvisited point
+                min_distance = float("inf")
+                nearest_point = None
 
-    except json.JSONDecodeError:
-        return JsonResponse({"error": "Invalid JSON data"}, status=400)
-    except KeyError:
-        return JsonResponse(
-            {"error": "Each point must have lat and lng fields"}, status=400
-        )
+                for point_idx in unvisited:
+                    point_lat = points[point_idx]["lat"]
+                    point_lng = points[point_idx]["lng"]
+                    distance = calculate_distance_haversine(
+                        current_lat, current_lng, point_lat, point_lng
+                    )
+
+                    if distance < min_distance:
+                        min_distance = distance
+                        nearest_point = point_idx
+
+                # Move to nearest point
+                optimized_order.append(nearest_point)
+                unvisited.remove(nearest_point)
+                total_distance += min_distance
+                current_point = nearest_point
+
+            return Response(
+                {
+                    "total_distance_km": round(total_distance, 2),
+                    "optimized_order": optimized_order,
+                    "points_count": len(points),
+                }
+            )
+
+        except KeyError:
+            return Response(
+                {"error": "Each point must have lat and lng fields"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/backend/routes/views.py
+++ b/backend/routes/views.py
@@ -19,6 +19,9 @@ class RouteViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
+        # Swagger 스키마 생성 시에는 모든 데이터 반환
+        if getattr(self, "swagger_fake_view", False):
+            return self.queryset.none()
         return self.queryset.filter(created_by=self.request.user)
 
     @action(detail=False, methods=["post"])

--- a/backend/tourism/views.py
+++ b/backend/tourism/views.py
@@ -218,7 +218,6 @@ class TourismAPIViewSet(viewsets.GenericViewSet):
     def get_serializer_class(self):
         """액션에 따른 serializer 클래스 반환"""
         if self.action == "regional":
-            return RegionalTourismRequestSerializer
         return RegionalTourismRequestSerializer
 
     @action(detail=False, methods=["post"])

--- a/backend/tourism/views.py
+++ b/backend/tourism/views.py
@@ -80,6 +80,14 @@ class TourismRecommendationViewSet(viewsets.GenericViewSet):
 
     permission_classes = [AllowAny]
 
+    def get_serializer_class(self):
+        """액션에 따른 serializer 클래스 반환"""
+        if self.action == "recommend":
+            return POIRecommendationRequestSerializer
+        elif self.action == "related":
+            return RelatedPOIRequestSerializer
+        return POIRecommendationRequestSerializer
+
     @action(detail=False, methods=["post"])
     def recommend(self, request):
         """
@@ -206,6 +214,12 @@ class TourismAPIViewSet(viewsets.GenericViewSet):
     """
 
     permission_classes = [AllowAny]
+
+    def get_serializer_class(self):
+        """액션에 따른 serializer 클래스 반환"""
+        if self.action == "regional":
+            return RegionalTourismRequestSerializer
+        return RegionalTourismRequestSerializer
 
     @action(detail=False, methods=["post"])
     def regional(self, request):


### PR DESCRIPTION
## Summary

This pull request refactors the API endpoints to use DRF (Django REST Framework) for improved consistency and maintainability. Key changes include:

-   **Adding an API version (`API_VERSION`) to `settings.py`** to apply a consistent prefix to all URLs.
-   **Converting function-based views to DRF's `APIView` class-based views** for better HTTP method handling.
-   Modifying `urls.py` to dynamically set API paths using the `settings.API_VERSION` variable.
-   Adding logic to the `tourism` and `routes` viewsets to **prevent errors during Swagger schema generation**.
-   Introducing the `get_serializer_class` method to the `tourism` viewsets to **use different serializers based on the action**.

These changes result in cleaner code, a more organized structure, and a more robust foundation for future API expansion and management.

---

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation update
-   [x] Code refactoring

---

## Changes

-   Added `API_VERSION = "/api/v1"` to `backend/eatgo/settings.py`.
-   Imported `settings` in `backend/eatgo/urls.py` and applied the `settings.API_VERSION` prefix to `kakaomap`, `routes`, `travel_courses`, and `tourism` URLs.
-   Changed function-based views to class-based views in `backend/kakaomap/urls.py` (e.g., `get_kakao_map` -> `KakaoMapView.as_view()`).
-   Converted existing function-based views in `backend/kakaomap/views.py` into classes that inherit from DRF's `APIView`.
-   Added exception handling logic to `RouteViewSet` in `backend/routes/views.py` for Swagger schema generation.
-   Added the `get_serializer_class` method to both `TourismRecommendationViewSet` and `TourismAPIViewSet` in `backend/tourism/views.py`.

---

## Notes

This refactoring ensures endpoint consistency and leverages DRF features more effectively. The transition to `APIView` classes provides a more flexible foundation for implementing additional functionalities like authentication and permissions in the future.