### PR TITLE
fix: specify the destination 'province with district'

### DIFF
--- a/frontend/components/plan/DestinationSelector.tsx
+++ b/frontend/components/plan/DestinationSelector.tsx
@@ -42,9 +42,10 @@ export const DestinationSelector: React.FC<DestinationSelectorProps> = ({
     };
 
     const handleDistrictPress = (districtName: string) => {
-        const newSelected = selectedDistricts.includes(districtName)
-            ? selectedDistricts.filter((d) => d !== districtName)
-            : [...selectedDistricts, districtName];
+        const fullDestinationName = `${selectedProvinceName} ${districtName}`;
+        const newSelected = selectedDistricts.includes(fullDestinationName)
+            ? selectedDistricts.filter((d) => d !== fullDestinationName)
+            : [...selectedDistricts, fullDestinationName];
 
         setSelectedDistricts(newSelected);
         onDestinationChange?.(newSelected);
@@ -139,7 +140,11 @@ export const DestinationSelector: React.FC<DestinationSelectorProps> = ({
                             <DestinationButton
                                 key={`${rowIndex}-${index}`}
                                 destination={item}
-                                isSelected={selectedItems.includes(item)}
+                                isSelected={
+                                    step === "province"
+                                        ? selectedItems.includes(item)
+                                        : selectedDistricts.some(d => d.endsWith(` ${item}`))
+                                }
                                 onPress={
                                     step === "province"
                                         ? handleProvincePress


### PR DESCRIPTION
## Summary

- make the destination is rendered with province + district 
- for example, 서울 강서구, 강원도 춘천



## Type of change

<!-- If there is not a type of change you are making, please delete the sections. -->

-   [ ] Bug fix
-   [x] New feature
-   [ ] Documentation update


